### PR TITLE
Issue #8: Add Tracking of Most Recent Game to Scorigami Table

### DIFF
--- a/src/data_types/game.py
+++ b/src/data_types/game.py
@@ -52,13 +52,19 @@ class Game:
 
     def __eq__(self, other):
         type_equal = type(self) == type(other)
-
-        return type_equal and self.winner_points == other.winner_points and self.loser_points == other.loser_points
+        teams_equal = self.winner == other.winner and self.loser == other.loser
+        scores_equal = self.winner_points == other.winner_points and self.loser_points == other.loser_points
+        return type_equal and teams_equal and scores_equal
 
     def __lt__(self, other):
         """compare by date
         """
         return parse_date_string(self.date) < parse_date_string(other.date)
+
+    def __gt__(self, other):
+        """compare by date
+        """
+        return parse_date_string(self.date) > parse_date_string(other.date)
 
     def to_json(self) -> Dict[str, any]:
         """return the json represention of this

--- a/src/scorigami_table.py
+++ b/src/scorigami_table.py
@@ -9,6 +9,7 @@ class TableEntry:
 
     def __init__(self, value='Empty', game=None):
         self.first_game: Game = game
+        self.last_game: Game = game
         self.value: str = value
 
     def __repr__(self):
@@ -16,6 +17,9 @@ class TableEntry:
 
     def __lt__(self, other):
         return self.first_game.winner_points < other.first_game.winner_points
+
+    def __gt__(self, other):
+        return self.first_game.winner_points > other.first_game.winner_points
 
     def __eq__(self, other):
         return self.first_game == other.first_game and self.value == other.value
@@ -40,10 +44,13 @@ class ScorigamiTable:
             key = (game.winner_points, game.loser_points)
 
             if key in self.unique_scores.keys():
-                # This score has occurred, See which game sooner
-                previous = self.unique_scores[key]
-                if previous.first_game < game:
-                    continue
+                # This score has occurred, check for updates
+                entry = self.unique_scores[key]
+                if entry.first_game > game:
+                    entry.first_game = game
+                elif entry.last_game < game:
+                    entry.last_game = game
+                continue
 
             # Unique Score
             entry = TableEntry(value='Filled', game=game)
@@ -61,8 +68,8 @@ class ScorigamiTable:
         """
         return self.get_entry(winner_score, loser_score).value
 
-    def get_game(self, winner_score: int, loser_score: int) -> Game:
-        """get the Game of the table entry for the given scoreline
+    def get_first_game(self, winner_score: int, loser_score: int) -> Game:
+        """get the first Game of the table entry for the given scoreline
 
         Args:
             winner_score (int): the winner's score
@@ -72,6 +79,18 @@ class ScorigamiTable:
             str: the Game for the specified table entry
         """
         return self.get_entry(winner_score, loser_score).first_game
+
+    def get_recent_game(self, winner_score: int, loser_score: int) -> Game:
+        """get the Game of the table entry for the given scoreline
+
+        Args:
+            winner_score (int): the winner's score
+            loser_score (int): the loser's score
+
+        Returns:
+            str: the Game for the specified table entry
+        """
+        return self.get_entry(winner_score, loser_score).last_game
 
     def get_entry(self, winner_score: int, loser_score: int) -> TableEntry:
         """get the TableEntry for the given score line

--- a/test/test_game.py
+++ b/test/test_game.py
@@ -45,7 +45,7 @@ def test_repr(sample_game):
 
 
 def test_equal_true(sample_game):
-    other_game = Game("Penn State", "Michigan", 100, 0, "Oct 31, 2020")
+    other_game = Game("Ohio State", "Michigan", 100, 0, "Oct 31, 2020")
     assert sample_game == other_game
 
 
@@ -62,3 +62,13 @@ def test_lt_true(sample_game):
 def test_lt_false(sample_game):
     other_game = Game("Rutgers", "Michigan", 99, 0, "Sep 30, 2020")
     assert not sample_game < other_game
+
+
+def test_gt_true(sample_game):
+    other_game = Game("Rutgers", "Michigan", 99, 0, "Nov 30, 2020")
+    assert not sample_game > other_game
+
+
+def test_tt_false(sample_game):
+    other_game = Game("Rutgers", "Michigan", 99, 0, "Sep 30, 2020")
+    assert sample_game > other_game

--- a/test/test_scorigami_table.py
+++ b/test/test_scorigami_table.py
@@ -72,27 +72,44 @@ def test_get_entry_filled(populated_table):
     assert result == expected
 
 
-def test_get_game_impossible(populated_table):
-    assert populated_table.get_game(0, 2) is None
+def test_get_first_game_impossible(populated_table):
+    assert populated_table.get_first_game(0, 2) is None
 
 
-def test_get_game_empty(populated_table):
-    assert populated_table.get_game(10, 0) is None
+def test_get_first_game_empty(populated_table):
+    assert populated_table.get_first_game(10, 0) is None
 
 
-def test_get_game_filled(populated_table):
-    result = populated_table.get_game(100, 0)
+def test_get_first_game_filled(populated_table):
+    result = populated_table.get_first_game(100, 0)
     expected = Game(
         'Penn State', 'Rutgers', 100, 0, 'Nov 2, 2020')
     assert result == expected
 
 
+def test_get_recent_game_impossible(populated_table):
+    assert populated_table.get_recent_game(0, 2) is None
+
+
+def test_get_recent_game_empty(populated_table):
+    assert populated_table.get_recent_game(10, 0) is None
+
+
+def test_get_recent_game_filled(populated_table):
+    newest_game = Game(
+        'Ohio State', 'Rutgers', 100, 0, 'Nov 5, 2020')
+    updated_table = populated_table
+    updated_table.add_games([newest_game])
+    result = updated_table.get_recent_game(100, 0)
+    assert result == newest_game
+
+
 def test_get_value_impossible(populated_table):
-    assert populated_table.get_game(0, 2) is None
+    assert populated_table.get_first_game(0, 2) is None
 
 
 def test_get_value_empty(populated_table):
-    assert populated_table.get_game(10, 0) is None
+    assert populated_table.get_first_game(10, 0) is None
 
 
 def test_get_value_filled(populated_table):


### PR DESCRIPTION
Closes #8, ensures the scorigami table now tracks both the first and last game of a given score line to occur.