### PR TITLE
Issue #3: Update Local Caching Scheme to only save relevant games

### DIFF
--- a/src/file_manger.py
+++ b/src/file_manger.py
@@ -2,8 +2,10 @@ import jinja2
 import os
 import json
 from data_types import Game
+from typing import List
 OUTPUT_DIR: str = f'docs{os.sep}'
 INPUT_DIR: str = './src/templates'
+CACHE_FILE = 'data/scorgiami_cache.json'
 
 
 def get_template(file_name: str) -> jinja2.Template:
@@ -33,28 +35,29 @@ def write_file(output: str, file_name: str):
         fp.write(output)
 
 
-def write_cache(game_dict):
+def write_cache(file_name: str, games: List[Game], years: List[int]):
+    json_games = [game.to_json() for game in games]
 
-    for year, games in game_dict.items():
-        output_file = f'data/cache_{year}.json'
-        updated_games = [game.to_json() for game in games]
-        with open(output_file, 'w') as fp:
-            json.dump(updated_games, fp)
+    cache = {
+        "years": years,
+        "games": json_games
+    }
+    with open(file_name, 'w') as fp:
+        json.dump(cache, fp)
 
 
-def read_cache():
-    all_games = {}
-    for root, dirs, files in os.walk('data'):
-        for file in files:
-            if 'cache' in file:
-                # extract year
-                year = int(file[6:-5])
-                games = []
-                with open(root + os.sep + file, 'r') as fp:
-                    games = json.load(fp)
-                    games = [Game.from_json(game) for game in games]
-                all_games[year] = games
-    return all_games
+def read_cache(file_name):
+    games = []
+    years = []
+
+    cache = {}
+    if os.path.exists(file_name):
+        with open(file_name, 'r') as fp:
+            cache = json.load(fp)
+            games = [Game.from_json(game) for game in cache['games']]
+            years = cache['years']
+
+    return games, years
 
 
 def check_directories():

--- a/src/generate_pages.py
+++ b/src/generate_pages.py
@@ -1,6 +1,9 @@
+from typing import ChainMap
 from file_manger import get_template, write_file, read_cache, write_cache, check_directories
 from scraper import get_games
 from scorigami_table import ScorigamiTable
+
+CACHE_FILE = 'data/scorgiami_cache.json'
 
 
 def generate_index(score_table):
@@ -12,8 +15,15 @@ def generate_index(score_table):
 
 if __name__ == "__main__":
     check_directories()
-    cached_games = read_cache()
-    all_games = get_games(cached_games)
+    cached_games, cached_years = read_cache(CACHE_FILE)
+    new_games, all_years = get_games(cached_years)
+
+    all_games = cached_games
+    for year, games in new_games.items():
+        all_games.extend(games)
+
     table = ScorigamiTable(all_games)
     generate_index(table)
-    write_cache(all_games)
+
+    important_games = table.extract_games()
+    write_cache(CACHE_FILE, important_games, all_years)

--- a/src/scorigami_table.py
+++ b/src/scorigami_table.py
@@ -29,10 +29,9 @@ class ScorigamiTable:
     """the whole scorigami table, tracking scores that have occureced
     """
 
-    def __init__(self, all_games: Dict[int, List[Game]]):
+    def __init__(self, all_games: List[Game]):
         self.unique_scores: Dict[Tuple[int, int], TableEntry] = {}
-        for year, games in all_games.items():
-            self.add_games(games)
+        self.add_games(all_games)
 
     def add_games(self, games: List[Game]):
         """add the given games to the scorigami table, checking if older/newer games exist
@@ -119,6 +118,22 @@ class ScorigamiTable:
             int: the highest score
         """
         return max(self.unique_scores.keys())[0]
+
+    def extract_games(self) -> List[Game]:
+        """get all of the relevant games from this scorigami table
+
+        Returns:
+            List[Game]: the first and last game of each scoreline
+        """
+        games = []
+        for entry in self.unique_scores.values():
+            first_game = entry.first_game
+            last_game = entry.last_game
+
+            games.append(first_game)
+            if first_game != last_game:
+                games.append(last_game)
+        return games
 
     def __len__(self):
         return len(self.unique_scores.keys())

--- a/src/scraper/scrape.py
+++ b/src/scraper/scrape.py
@@ -7,11 +7,11 @@ import datetime
 from typing import Dict, List
 
 
-def get_games(all_games: Dict[int, List[Game]], ignore_current=True) -> Dict[int, List[Game]]:
+def get_games(cached_years: List[int], ignore_current=True) -> Dict[int, List[Game]]:
     """get data for all CFB games that have been played, accounting for cached games
 
     Args:
-        all_games (Dict[int, List[Game]]): the cached games
+        cached_years (List[int]): the years to skip
         ignore_current (bool, optional): to ignore current eyar in cache. Defaults to True.
 
     Returns:
@@ -19,19 +19,25 @@ def get_games(all_games: Dict[int, List[Game]], ignore_current=True) -> Dict[int
     """
     starting_year: int = 1869  # first year of CFB
     ending_year: int = datetime.datetime.now().year  # get up to date data
-    cached_years: List[int] = all_games.keys()
 
+    all_games = {}
+
+    if ignore_current and ending_year in cached_years:
+        cached_years.remove(ending_year)
+
+    all_years = cached_years
     # Loop through all Years
     for current_year in range(starting_year, ending_year + 1):
         # Check cache, except current year. Get up to date data
-        if current_year in cached_years and (current_year != ending_year or not ignore_current):
+        if current_year in cached_years:
             print(f'Data for {current_year} found in cache')
             continue
         print(f'Currently Scraping Year {current_year}')
         table_rows = _get_year_data(current_year)
         all_games[current_year] = _process_year_data(table_rows)
+        all_years.append(current_year)
 
-    return all_games
+    return all_games, all_years
 
 
 def _get_year_data(year: int) -> List[BeautifulSoup]:

--- a/test/data/cache_output.json
+++ b/test/data/cache_output.json
@@ -1,0 +1,1 @@
+{"years": [1869], "games": [{"winner": "Rutgers", "loser": "Princeton", "winner_points": 6, "loser_points": 4, "date": "Nov 6, 1869"}, {"winner": "Princeton", "loser": "Rutgers", "winner_points": 8, "loser_points": 0, "date": "Nov 13, 1869"}]}

--- a/test/data/sample_cache.json
+++ b/test/data/sample_cache.json
@@ -1,0 +1,1 @@
+{"years": [1869], "games": [{"winner": "Rutgers", "loser": "Princeton", "winner_points": 6, "loser_points": 4, "date": "Nov 6, 1869"}, {"winner": "Princeton", "loser": "Rutgers", "winner_points": 8, "loser_points": 0, "date": "Nov 13, 1869"}]}

--- a/test/test_file_manager.py
+++ b/test/test_file_manager.py
@@ -1,0 +1,43 @@
+import pytest
+from . import context
+from file_manger import read_cache, write_cache
+from data_types import Game
+
+
+@pytest.fixture
+def sample_games():
+
+    games = [
+        Game("Rutgers", "Princeton", 6, 4, "Nov 6, 1869"),
+        Game("Princeton", "Rutgers", 8, 0, "Nov 13, 1869")
+    ]
+    return games
+
+
+@pytest.fixture
+def sample_years():
+    years = [1869]
+    return years
+
+
+def test_read_cache(sample_games, sample_years):
+    input_file = 'test/data/sample_cache.json'
+    games, years = read_cache(input_file)
+    assert games == sample_games
+    assert years == sample_years
+
+
+def test_write_cache(sample_games, sample_years):
+    output_file = 'test/data/cache_output.json'
+    input_file = 'test/data/sample_cache.json'
+    write_cache(output_file, sample_games, sample_years)
+
+    expected = ''
+    with open(input_file, 'r') as fp:
+        expected = fp.read()
+
+    result = ''
+    with open(output_file, 'r') as fp:
+        result = fp.read()
+
+    assert result == expected

--- a/test/test_scorigami_table.py
+++ b/test/test_scorigami_table.py
@@ -11,7 +11,7 @@ IMPOSSIBLE_ENTRY = TableEntry('Impossible')
 def sample_games():
     samples = [
         Game('Ohio State', 'Michigan', 100, 0, 'Nov 3, 2020'),
-        Game('Penn State', 'Rutgers', 100, 0, 'Nov 3, 2020'),
+        Game('Penn State', 'Rutgers', 100, 0, 'Nov 2, 2020'),
         Game('Clemson', 'Alabama', 23, 20, 'Nov 3, 2020'),
         Game('Ohio State', 'Michigan State', 17, 7, 'Nov 3, 2020'),
     ]
@@ -26,23 +26,23 @@ def populated_table():
         Game('Clemson', 'Alabama', 23, 20, 'Nov 3, 2020'),
         Game('Ohio State', 'Michigan State', 17, 7, 'Nov 3, 2020'),
     ]
-    return ScorigamiTable({2020: samples})
+    return ScorigamiTable(samples)
 
 
 def test_constructor(sample_games):
-    table = ScorigamiTable({2020: sample_games})
+    table = ScorigamiTable(sample_games)
     assert len(table) == 3
 
 
 def test_add_games_empty():
-    table = ScorigamiTable({})
+    table = ScorigamiTable([])
     table.add_games([])
 
     assert len(table) == 0
 
 
 def test_add_games_nonempty(sample_games):
-    table = ScorigamiTable({})
+    table = ScorigamiTable([])
 
     table.add_games(sample_games)
 
@@ -50,7 +50,7 @@ def test_add_games_nonempty(sample_games):
 
 
 def test_add_games_has_value(sample_games):
-    table = ScorigamiTable({})
+    table = ScorigamiTable([])
 
     table.add_games(sample_games)
 
@@ -120,3 +120,23 @@ def test_get_value_filled(populated_table):
 
 def test_get_max_score(populated_table):
     assert populated_table.max_score() == 100
+
+
+def test_extract_games_no_useless(populated_table, sample_games):
+    result = populated_table.extract_games()
+    expected = sample_games
+
+
+def test_extract_games_useless_games(populated_table):
+    expected = [
+        Game('Ohio State', 'Rutgers', 100, 0, 'Nov 5, 2020'),
+        Game('Penn State', 'Rutgers', 100, 0, 'Nov 2, 2020'),
+        Game('Clemson', 'Alabama', 23, 20, 'Nov 3, 2020'),
+        Game('Ohio State', 'Michigan State', 17, 7, 'Nov 3, 2020'),
+    ]
+    newest_game = Game(
+        'Ohio State', 'Rutgers', 100, 0, 'Nov 5, 2020')
+    updated_table = populated_table
+    updated_table.add_games([newest_game])
+    result = updated_table.extract_games()
+    assert sorted(result) == sorted(expected)

--- a/test/test_scrape.py
+++ b/test/test_scrape.py
@@ -13,7 +13,7 @@ def sample_rows():
 
 
 def get_fake_cache():
-    return {i: [] for i in range(1870, 2021)}
+    return [i for i in range(1870, 2021)]
 
 # Test Get Year Data
 
@@ -70,30 +70,42 @@ def test_process_year_data_correct_game(sample_rows):
 def test_get_games_ignore_current_year_true():
     current_year = datetime.datetime.now().year
     fake_cache = get_fake_cache()
-    result = scrape.get_games(fake_cache)
+    result, years = scrape.get_games(fake_cache)
+    current_year = datetime.datetime.now().year
+    expected_years = [i for i in range(1869, current_year + 1)]
+    assert sorted(years) == sorted(expected_years)
     assert len(result[current_year]) > 0
 
 
 def test_get_games_ignore_current_year_false():
     current_year = datetime.datetime.now().year
     fake_cache = get_fake_cache()
-    result = scrape.get_games(fake_cache, ignore_current=True)
+    result, years = scrape.get_games(fake_cache, ignore_current=True)
+    current_year = datetime.datetime.now().year
+    expected_years = [i for i in range(1869, current_year + 1)]
+    assert sorted(years) == sorted(expected_years)
     assert len(result[current_year]) > 0
 
 
 def test_get_games_1869_correct():
     fake_cache = get_fake_cache()
-    result = scrape.get_games(fake_cache)
+    result, years = scrape.get_games(fake_cache)
 
     expected = [
         Game("Rutgers", "Princeton", 6, 4, "Nov 6, 1869"),
         Game("Princeton", "Rutgers", 8, 0, "Nov 13, 1869")
     ]
+    current_year = datetime.datetime.now().year
+    expected_years = [i for i in range(1869, current_year + 1)]
+    assert sorted(years) == sorted(expected_years)
     assert result[1869] == expected
 
 
 def test_get_games_skip_cache():
-    fake_cache = get_fake_cache()
-    result = scrape.get_games(fake_cache)
 
-    assert result[1870] == []
+    fake_cache = get_fake_cache()
+    result, years = scrape.get_games(fake_cache)
+    current_year = datetime.datetime.now().year
+    expected_years = [i for i in range(1869, current_year + 1)]
+    assert sorted(years) == sorted(expected_years)
+    assert 1870 not in result.keys()


### PR DESCRIPTION
Closes #3. Change the caching scheme to only save the first/last game of each score line, as well as store the years that have been scraped. This required changes in many aspects of the code.